### PR TITLE
Add emails on failure

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -92,6 +92,7 @@ jobs:
         - name: ci
       outputs:
         - name: brats-ouput
+        - name: mail-output
       params:
         GINKGO_NODES: 1
         PROXY_SCHEME: {{brats-proxy-scheme}}
@@ -108,6 +109,11 @@ jobs:
         PROJECT: {{obs-buildpacks-staging-project}}
       run:
         path: ci/tasks/brats.sh
+    on_failure: 
+      put: email.suse
+      params:
+        subject: mail-output/subject-failed.txt
+        body: mail-output/body-failed.txt
 - name: release
   plan:
   - get: ci

--- a/tasks/brats.sh
+++ b/tasks/brats.sh
@@ -14,7 +14,7 @@ ${BUILDPACK} has not been build (already released)
 EOF
 cat << EOF > mail-output/body-failed.txt
 ${BUILDPACK} has not been build (already released) 
-See https://ci.howdoi.website/teams/main/pipelines/buildpacks-ci/ for details.
+See https://ci.howdoi.website/teams/main/pipelines/buildpacks-ci for details.
 EOF
   exit 1
 fi
@@ -39,6 +39,6 @@ ${BUILDPACK} has not been build (BRATS have failed)
 EOF
 cat << EOF > mail-output/body-failed.txt
 ${BUILDPACK} has not been build (BRATS have failed) 
-See https://ci.howdoi.website/teams/main/pipelines/buildpacks-ci/ for details.
+See https://ci.howdoi.website/teams/main/pipelines/buildpacks-ci for details.
 EOF
 fi

--- a/tasks/brats.sh
+++ b/tasks/brats.sh
@@ -4,10 +4,18 @@ set -e
 
 pushd lftp.obs-buildpacks-staging > /dev/null
 VERSION=$(ls *.src.rpm | sed -E 's/.*buildpack-([0-9.].+)-.*/\1/')
+BUILDPACK=$(ls *.src.rpm | sed -E 's/(.*buildpack-[0-9.].+)-.*/\1/')
 popd > /dev/null
 
 if ls s3-buildpacks/*buildpack-v${VERSION}-*.zip > /dev/null 2>&1; then
   echo -e "The buildpack with the version $VERSION was already released, exiting ..."
+cat << EOF > mail-output/subject-failed.txt
+${BUILDPACK} has not been build (already released) 
+EOF
+cat << EOF > mail-output/body-failed.txt
+${BUILDPACK} has not been build (already released) 
+See https://ci.howdoi.website/teams/main/pipelines/buildpacks-ci/ for details.
+EOF
   exit 1
 fi
 
@@ -24,3 +32,13 @@ cp cf-ruby-buildpack-*/VERSION ../ruby-buildpack/
 cd ../ruby-buildpack
 
 scripts/brats.sh
+
+if [ $? -ne 0 ]; then
+cat << EOF > mail-output/subject-failed.txt
+${BUILDPACK} has not been build (BRATS have failed) 
+EOF
+cat << EOF > mail-output/body-failed.txt
+${BUILDPACK} has not been build (BRATS have failed) 
+See https://ci.howdoi.website/teams/main/pipelines/buildpacks-ci/ for details.
+EOF
+fi


### PR DESCRIPTION
This PR adds an additional mail-output to the pipeline which is triggered when BRATS have failed or when the buildpack has already been released.