### PR TITLE
Clean up services

### DIFF
--- a/brats/tasks/cleanup.sh
+++ b/brats/tasks/cleanup.sh
@@ -9,3 +9,6 @@ for app in $(cf apps | awk '{print $1}'); do cf delete -f $app; done
 
 # Delete all buildpacks (in case there are leftovers)
 for buildpack in $(cf buildpacks | tail -n +4 | awk '{print $1}'); do cf delete-buildpack -f $buildpack; done
+
+# Delete all services 
+for service in $(cf services | tail -n +4 | awk '{print $1}'); do cf delete-service -f $service; done


### PR DESCRIPTION
Some integration tests are using fixed name during the test run.
We need to cleanup them as well, because if we e.g. abort the build,
services will be still pending inside the cluster.

Signed-off-by: Christian Richter <crichter@suse.com>