### PR TITLE
Use ephemeral clusters for BRATs

### DIFF
--- a/brats/README.md
+++ b/brats/README.md
@@ -1,0 +1,29 @@
+# Brats pipeline
+
+The brats pipeline can be locally or deployed internally using [Catapult](https://github.com/SUSE/catapult) and [EKCP](https://github.com/mudler/ekcp).
+
+## Deployment instructions
+
+### Install ekcp
+
+Ekcp has to be installed in a node which is reachable from the concourse workers. Instructions can be found [here](https://github.com/mudler/ekcp/wiki/Single-node-setup).
+
+### Adapt the pipeline to point to a cluster
+
+- Choose a unique name for your cluster, e.g. *brats* , and replace  accordingly `CLUSTER_NAME` value in the pipeline.
+- Define `EKCP_HOST` to point where you deployed ekcp. e.g. *ip:port*
+- Deploy the brats pipeline with `TARGET=concourse ./deploy.sh brats`
+
+You can specify in this step also a `SCF_CHART` in the `force_redeploy_cluster` job which points to the SCF chart you wish to deploy.
+
+### Create the cluster suitable for running BRATS tests
+
+At this point, what is you need to do is just to trigger the `force_redeploy_cluster` job in the pipeline, which will create a new cluster configured for brats.
+
+### Deploy the nginx proxy
+
+Some BRATS tests might need an nginx proxy on the cluster to test redacted credentials from output, when downloading buildpack dependencies.
+
+To setup the proxy, there is a make target to do that in [Catapult](https://github.com/SUSE/catapult), which is `module-extra-brats-setup`, for reference [here is defined the source code and the steps](https://github.com/SUSE/catapult/blob/46328a500e2dd75d3e437a8156963bc221bdd76e/modules/scf/brats_setup.sh), which includes the deployment of an nginx proxy.
+
+In case the brats setup needs to be run manually, note that it needs to connect directly to SCF, and the make target might need to be run inside a pod in the cluster. (you an do that with `make module-extra-terminal` in Catapult).

--- a/brats/pipeline.yaml
+++ b/brats/pipeline.yaml
@@ -25,6 +25,11 @@ resources:
   source:
     uri: git@github.com:SUSE/buildpacks-ci.git
     private_key: {{github-private-key}}
+- name: catapult
+  type: git
+  source:
+    uri: git@github.com:SUSE/catapult.git
+    private_key: {{github-private-key}}
 <% buildpacks.each do |buildpack| %>
 - name: gh-release.<%= buildpack %>-buildpack
   type: github-release
@@ -90,6 +95,40 @@ resources:
 <% end %>
 <% end %>
 jobs:
+# When a cluster is already there, we don't clean up and just reuse it. It is useful to be
+# able to redeploy the cluster manually in cases like:
+# - We need a latest version of CAP deployed
+# - The cluster is broken because of some previous operation
+# This task can be manually triggered to force a redeploy of the brats cluster.
+- name: force_redeploy_cluster
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: catapult
+  - task: deploy-cluster
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+        - name: catapult
+        - name: ci
+      params:
+        DEFAULT_STACK: sle15
+        DOCKER_ORG: cap-staging
+        SCF_CHART: "https://s3.amazonaws.com/cap-release-archives/prs/PR-2686-scf-sle-2.18.0.1%2Bcf9.5.0.288.gef2d9512.zip"
+        ENABLE_EIRINI: false
+        DIEGO_SIZING: 3
+        EKCP_HOST: {{ekcp-host}}
+        EKCP_PROXY: 1
+        EKCP_DOMAIN: nip.io
+        KIND_VERSION: 0.2.1
+        CLUSTER_NAME: diegobrats
+      run:
+        path: ci/brats/tasks/deploy-cluster.sh
 <% buildpacks.each do |buildpack| %>
 - name: check-<%= buildpack %>-artifacts-published
   plan:
@@ -158,21 +197,25 @@ jobs:
     - get: ci
     - get: git.cf-<%= buildpack %>-buildpack-readonly
     - get: gh-release.<%= buildpack %>-buildpack
+    - get: catapult
   - task: cleanup
     config:
       platform: linux
       image_resource:
         type: registry-image
         source:
-          repository: splatform/concourse-brats
+          repository: splatform/catapult
       inputs:
         - name: ci
+        - name: catapult
       params:
-        CF_ENDPOINT: {{brats-cf-endpoint}}
-        CF_USERNAME: {{brats-cf-username}}
-        CF_PASSWORD: {{brats-cf-password}}
-        CF_ORG: {{brats-cf-org}}
-        CF_SPACE: {{brats-cf-space}}
+        DEFAULT_STACK: sle15
+        EKCP_HOST: {{ekcp-host}}
+        EKCP_PROXY: 1
+        EKCP_DOMAIN: nip.io
+        CF_STACK: {{brats-cf-stack}}
+        KIND_VERSION: 0.2.1
+        CLUSTER_NAME: diegobrats
       run:
         path: ci/brats/tasks/cleanup.sh
 #    on_failure:
@@ -190,33 +233,25 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: splatform/concourse-brats
+          repository: splatform/catapult
       inputs:
         - name: git.cf-buildpack
         - name: gh-release.buildpack
         - name: s3.suse-buildpacks-staging
+        - name: catapult
         - name: ci
       outputs:
         - name: mail-output
       params:
-        BUILDPACK: <%= buildpack %>
-        TEST_SUITE: brats
-        PROXY_SCHEME: {{brats-proxy-scheme}}
-        PROXY_PORT: {{brats-proxy-port}}
-        PROXY_USERNAME: {{brats-proxy-username}}
-        PROXY_PASSWORD: {{brats-proxy-password}}
-        PROXY_HOST: {{brats-proxy-host}}
+        BRATS_BUILDPACK: <%= buildpack %>
         CF_STACK: {{brats-cf-stack}}
-        CF_ENDPOINT: {{brats-cf-endpoint}}
-        CF_USERNAME: {{brats-cf-username}}
-        CF_PASSWORD: {{brats-cf-password}}
-        CF_ORG: {{brats-cf-org}}
-        CF_SPACE: {{brats-cf-space}}
-        PROJECT: {{obs-buildpacks-staging-project}}
-        GIT_MAIL: {{github-username}}
-        GIT_USER: suse-cf-ci-bot
-        GINKGO_NODES: 5
+        GINKGO_NODES: 2
         GINKGO_ATTEMPTS: 3
+        EKCP_HOST: {{ekcp-host}}
+        EKCP_DOMAIN: nip.io
+        KIND_VERSION: 0.2.1
+        CLUSTER_NAME: diegobrats
+        BRATS_TEST_SUITE: brats
       run:
         path: ci/brats/tasks/run-tests.sh
 #    on_failure:
@@ -237,6 +272,7 @@ jobs:
       passed:
       - run-<%= buildpack %>-brats
     <% end %>
+    - get: catapult
     - get: ci
     - get: git.cf-<%= buildpack %>-buildpack-readonly
     - get: gh-release.<%= buildpack %>-buildpack
@@ -246,15 +282,21 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: splatform/concourse-brats
+          repository: splatform/catapult
       inputs:
         - name: ci
+        - name: catapult
       params:
         CF_ENDPOINT: {{brats-cf-endpoint}}
+        EKCP_HOST: {{ekcp-host}}
+        EKCP_DOMAIN: nip.io
         CF_USERNAME: {{brats-cf-username}}
+        CF_STACK: {{brats-cf-stack}}
         CF_PASSWORD: {{brats-cf-password}}
         CF_ORG: {{brats-cf-org}}
         CF_SPACE: {{brats-cf-space}}
+        CLUSTER_NAME: diegobrats
+        BRATS_BUILDPACK: <%= buildpack %>
       run:
         path: ci/brats/tasks/cleanup.sh
 #    on_failure:
@@ -273,17 +315,19 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: splatform/concourse-brats
+          repository: splatform/catapult
       inputs:
         - name: git.cf-buildpack
         - name: gh-release.buildpack
         - name: s3.suse-buildpacks-staging
         - name: ci
+        - name: catapult
       outputs:
         - name: mail-output
       params:
         BUILDPACK: <%= buildpack %>
-        TEST_SUITE: integration
+        BRATS_BUILDPACK: <%= buildpack %>
+        BRATS_TEST_SUITE: integration
         PROXY_SCHEME: {{brats-proxy-scheme}}
         PROXY_PORT: {{brats-proxy-port}}
         PROXY_USERNAME: {{brats-proxy-username}}
@@ -300,8 +344,13 @@ jobs:
         GIT_MAIL: {{github-username}}
         GIT_USER: suse-cf-ci-bot
         COMPOSER_GITHUB_OAUTH_TOKEN: {{github-limited-token}} # Needed for PHP integration tests
-        GINKGO_ATTEMPTS: 3
-        GINKGO_NODES: 5
+        GINKGO_ATTEMPTS: 5
+        GINKGO_NODES: 2
+        EKCP_HOST: {{ekcp-host}}
+        EKCP_PROXY: 1
+        EKCP_DOMAIN: nip.io
+        KIND_VERSION: 0.2.1
+        CLUSTER_NAME: diegobrats
       run:
         path: ci/brats/tasks/run-tests.sh
 #    on_failure:

--- a/brats/tasks/cf_login.sh
+++ b/brats/tasks/cf_login.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-cf login --skip-ssl-validation -a $CF_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE

--- a/brats/tasks/cleanup.sh
+++ b/brats/tasks/cleanup.sh
@@ -2,13 +2,15 @@
 
 set -e
 
-source ci/brats/tasks/cf_login.sh
+export QUIET_OUTPUT=true
+export BACKEND=ekcp
+cd catapult
 
-# Delete leftover apps
-for app in $(cf apps | awk '{print $1}'); do cf delete -f $app; done
+make recover
 
-# Delete all buildpacks (in case there are leftovers)
-for buildpack in $(cf buildpacks | tail -n +4 | awk '{print $1}'); do cf delete-buildpack -f $buildpack; done
-
-# Delete all services 
-for service in $(cf services | tail -n +4 | awk '{print $1}'); do cf delete-service -f $service; done
+export TASK_SCRIPT="$PWD/clean.sh"
+echo "#!/bin/bash" > $TASK_SCRIPT
+echo "CF_STACK=$CF_STACK make scf-purge" >> $TASK_SCRIPT
+echo "CF_STACK=cflinuxfs3 make scf-purge" >> $TASK_SCRIPT
+chmod +x $TASK_SCRIPT
+make module-extra-task

--- a/brats/tasks/deploy-cluster.sh
+++ b/brats/tasks/deploy-cluster.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+pushd catapult
+
+# Deploy SCF
+export BACKEND=ekcp
+export FORCE_CLEAN=true
+export QUIET_OUTPUT=true
+export TASK_SCRIPT="$PWD/proxy.sh"
+
+echo "#!/bin/bash" > $TASK_SCRIPT
+echo "make module-extra-brats-setup" >> $TASK_SCRIPT
+chmod +x $TASK_SCRIPT
+make scf-deploy module-extra-ingress module-extra-task

--- a/brats/tasks/run-tests.sh
+++ b/brats/tasks/run-tests.sh
@@ -4,57 +4,14 @@ set -e -o pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-rpm -e chromedriver
-wget -O chromedriver.zip 'https://chromedriver.storage.googleapis.com/2.34/chromedriver_linux64.zip'
-[ e42a55f9e28c3b545ef7c7727a2b4218c37489b4282e88903e4470e92bc1d967 = "$(shasum -a 256 chromedriver.zip | cut -d' ' -f1)" ]
-unzip chromedriver.zip -d /usr/local/bin/
-rm chromedriver.zip
-
 echo "[CI] ${BUILDPACK} ${TEST_SUITE} tests have failed" > mail-output/subject-failed.txt
 
-source ci/brats/tasks/cf_login.sh 2>&1 | tee mail-output/body-failed.txt
+export BRATS_BUILDPACK=${BRATS_BUILDPACK}
+export BRATS_BUILDPACK_VERSION=$(cat gh-release.buildpack/version)
+export BRATS_BUILDPACK_URL=$(cat s3.suse-buildpacks-staging/url)
+export BACKEND=ekcp
+export QUIET_OUTPUT=true
 
-# Setup git
-git config --global user.email "${GIT_MAIL}"
-git config --global user.name "${GIT_USER}"
-
-UPSTREAM_VERSION=$(cat gh-release.buildpack/version)
-
-# make sure that we do not test the git version but the buildpack one
-cd git.cf-buildpack
-
-# Make sure we can check out our remote branch because concourse restricts to master
-git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
-git fetch origin
-git checkout ${UPSTREAM_VERSION}
-
-# Make sure the manifest and version file from git are not used
-rm manifest.yml VERSION 2>&1 | tee ../mail-output/body-failed.txt
-
-unzip ../s3.suse-buildpacks-staging/*.zip  manifest.yml VERSION 2>&1 | tee ../mail-output/body-failed.txt
-
-# In some cases the manifest stays intact after inflation and we don't want
-# the script to exit because there is nothing to commit.
-# (e.g. the binary buildpack comes from upstream)
-if [[ -n $(git status -s | grep ' M') ]]; then
-  git commit manifest.yml VERSION -m "Replace manifest and VERSION by the version to test" 2>&1 | tee ../mail-output/body-failed.txt
-fi
-
-if [ "${TEST_SUITE}" == "brats" ]; then
-  scripts/${TEST_SUITE}.sh 2>&1 | tee ../mail-output/body-failed.txt
-else
-  export CF_STACK_DOCKER_IMAGE=registry.opensuse.org/cloud/platform/stack/rootfs/images/sle15:latest
-  # Mount cgroups to be able to call docker in docker
-  echo "Setup CGroups"
-  source $SCRIPT_DIR/helpers.sh
-  sanitize_cgroups
-
-  echo "Starting docker daemon"
-  # Start docker daemon and wait until it's up
-  start_docker
-  docker version
-  echo "Docker is up and running!"
-
-  # Do not fail on integration tests at the moment
-  scripts/${TEST_SUITE}.sh 2>&1 | tee ../mail-output/body-failed.txt
-fi
+pushd catapult
+make recover tests-brats | tee ../mail-output/body-failed.txt
+popd


### PR DESCRIPTION
This allows us to easily redeploy the cluster which is used to run the test against, as it will be automatically configured to run BRATs test (including nginx setup)